### PR TITLE
Refactor: Use next-intl Link for locale preservation

### DIFF
--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import Link from "next/link";
+import { Link } from "@/i18n/routing";
 import { useTranslations } from "next-intl";
 import { useBlogStore } from "@/store/blogStore";
 import Image from "next/image";

--- a/src/components/DesktopHeader.tsx
+++ b/src/components/DesktopHeader.tsx
@@ -1,61 +1,23 @@
 "use client";
 
 import { HeaderProps } from "@/types/HeaderTypes";
-import { scrollToElement } from "@/utils/utils";
+import { Link } from "@/i18n/routing";
 
 const DesktopHeader = ({ links, handlePitchClick }: HeaderProps) => {
-  const handleSmoothScroll = (e: React.MouseEvent, targetId: string) => {
-    e.preventDefault();
-
-    // Determinar si es un enlace a una página o sección
-    const isFullPageLink = targetId.startsWith("/");
-
-    // Si es un enlace completo (como /blog, /portfolio, etc.)
-    if (isFullPageLink) {
-      // En caso de portfolio, mantener el comportamiento actual
-      if (targetId === "/portfolio") {
-        window.location.href = "es" + targetId;
-        return;
-      }
-
-      // Para otros enlaces completos (/blog, /services, etc.)
-      const locale = window.location.pathname.split("/")[1] || "es";
-      window.location.href = `/${locale}${targetId}`;
-      return;
-    }
-
-    // El código existente para secciones dentro de la página (servicios, contacto, etc.)
-    let pathname = window.location.pathname;
-    // quitamos locale
-    const locale = pathname.split("/")[1];
-    pathname = pathname.substring(locale.length + 1);
-
-    const inHome = pathname === "";
-
-    if (inHome) {
-      // Usar nuestra nueva función de scroll con offset
-      scrollToElement(targetId);
-      return;
-    }
-
-    // entonces quiero ir a home diciéndole scroll hasta la section href
-    window.location.href = `/#${targetId}`;
-  };
-
   return (
     <nav>
       {" "}
       <ul className="flex space-x-6 items-center">
         {links.map((link: { href: string; label: string }) => (
           <li key={`${link.href}${link.label}`}>
-            <button
+            <Link
+              href={link.href}
               className="text-black dark:text-white
               hover:text-primary
               dark:hover:text-accent transition-colors duration-300"
-              onClick={(e) => handleSmoothScroll(e, link.href)}
             >
               {link.label}
-            </button>
+            </Link>
           </li>
         ))}
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import Link from "next/link";
+import { Link } from "@/i18n/routing";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 

--- a/src/components/MobileHeader.tsx
+++ b/src/components/MobileHeader.tsx
@@ -2,52 +2,11 @@
 
 import { useState, useEffect } from "react";
 import { Menu, X } from "lucide-react";
-import { scrollToElement } from "@/utils/utils";
 import { HeaderProps } from "@/types/HeaderTypes";
+import { Link } from "@/i18n/routing";
 
 const MobileHeader = ({ links, handlePitchClick }: HeaderProps) => {
   const [menuOpen, setMenuOpen] = useState(false);
-  const handleSmoothScroll = (e: React.MouseEvent, targetId: string) => {
-    e.preventDefault();
-
-    // Determinar si es un enlace a una página o sección
-    const isFullPageLink = targetId.startsWith("/");
-
-    // Si es un enlace completo (como /blog, /portfolio, etc.)
-    if (isFullPageLink) {
-      // Close menu first
-      setMenuOpen(false);
-
-      // En caso de portfolio, mantener el comportamiento actual
-      if (targetId === "/portfolio") {
-        window.location.href = "es" + targetId;
-        return;
-      }
-
-      // Para otros enlaces completos (/blog, /services, etc.)
-      const locale = window.location.pathname.split("/")[1] || "es";
-      window.location.href = `/${locale}${targetId}`;
-      return;
-    }
-
-    let pathname = window.location.pathname;
-    // quitamos locale
-    const locale = pathname.split("/")[1];
-    pathname = pathname.substring(locale.length + 1);
-
-    const inHome = pathname === "";
-
-    if (inHome) {
-      // Close menu first
-      setMenuOpen(false);
-      // Usar nuestra nueva función de scroll con offset
-      scrollToElement(targetId);
-      return;
-    }
-
-    // entonces quiero ir a home diciéndole scroll hasta la section href
-    window.location.href = `/#${targetId}`;
-  };
 
   // Close menu when clicking outside
   useEffect(() => {
@@ -94,18 +53,16 @@ const MobileHeader = ({ links, handlePitchClick }: HeaderProps) => {
              "
         >
           {links.map((link) => (
-            <button
+            <Link
               key={`${link.href}${link.label}`}
+              href={link.href}
               className="block w-full text-left px-4 py-2 text-sm 
               text-dark dark:text-white 
              "
-              onClick={(e) => {
-                setMenuOpen(false);
-                handleSmoothScroll(e, link.href);
-              }}
+              onClick={() => setMenuOpen(false)}
             >
               {link.label}
-            </button>
+            </Link>
           ))}
           <button
             className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"

--- a/src/components/ProjectPreview.tsx
+++ b/src/components/ProjectPreview.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { Link } from "@/i18n/routing";
 import Image from "next/image";
 
 // Define the project type


### PR DESCRIPTION
I've updated various components to use the Link component from 'next-intl/routing' instead of 'next/link' or manual `window.location.href` manipulation.

This change ensures that the current language locale is maintained consistently when navigating between pages and sections of the application.

Files modified:
- src/components/Footer.tsx
- src/components/ProjectPreview.tsx
- src/app/[locale]/blog/page.tsx
- src/components/DesktopHeader.tsx
- src/components/MobileHeader.tsx